### PR TITLE
retrieve repository id using octokit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
     decription: 'Required when changing org level secrets. Defaults to "selected"'
     required: false
     default: 'selected'
+  repository:
+    description: 'The repository to add the secret to. Defaults to the repository running this action'
+    default: '${{ github.repository }}'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -11909,7 +11909,7 @@ async function run() {
     const value = core.getInput('value');  // required
     const visibility = core.getInput('visibility'); // optional
     const octokit = github.getOctokit(token);
-    const [org, repo] = context.payload.repository.full_name.split('/');
+    const [org, repo] = core.getInput('repository').split('/');
     const repository_id = (await octokit.rest.repos.get({
       owner: org, 
       repo: repo

--- a/dist/index.js
+++ b/dist/index.js
@@ -11909,8 +11909,11 @@ async function run() {
     const value = core.getInput('value');  // required
     const visibility = core.getInput('visibility'); // optional
     const octokit = github.getOctokit(token);
-    const repository_id = context.payload.repository.id
     const [org, repo] = context.payload.repository.full_name.split('/');
+    const repository_id = (await octokit.rest.repos.get({
+      owner: org, 
+      repo: repo
+    })).id;
     core.setSecret(value);
 
     core.debug(`location: ${loc}`);

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ async function run() {
     const value = core.getInput('value');  // required
     const visibility = core.getInput('visibility'); // optional
     const octokit = github.getOctokit(token);
-    const [org, repo] = context.payload.repository.full_name.split('/');
+    const [org, repo] = core.getInput('repository').split('/');
     const repository_id = (await octokit.rest.repos.get({
       owner: org, 
       repo: repo

--- a/src/index.js
+++ b/src/index.js
@@ -11,8 +11,11 @@ async function run() {
     const value = core.getInput('value');  // required
     const visibility = core.getInput('visibility'); // optional
     const octokit = github.getOctokit(token);
-    const repository_id = context.payload.repository.id
     const [org, repo] = context.payload.repository.full_name.split('/');
+    const repository_id = (await octokit.rest.repos.get({
+      owner: org, 
+      repo: repo
+    })).id;
     core.setSecret(value);
 
     core.debug(`location: ${loc}`);


### PR DESCRIPTION
Existing implementation was leading to this error:

<img width="521" alt="Screen Shot 2022-08-12 at 6 59 39 PM" src="https://user-images.githubusercontent.com/662419/184461567-d7580c80-70c0-407b-b5fb-46fde263a193.png">

The issue is caused by [this](https://github.com/dacbd/gha-secrets/blob/main/src/index.js#L14) line which is trying to retrieve `id`, however the `id` property doesn't actually exist as seen [here](https://github.com/actions/toolkit/blob/main/packages/github/src/interfaces.ts#L3-L13).