### PR TITLE
Feat/upgrade nodejs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
       - run: echo "${{ secrets.GHA_SECRETS_TEST }}" | md5sum
       - name: Keep previous test value
         id: previous
-        run: echo '::set-output name=value::${{ secrets.GHA_SECRETS_TEST }}'
+        run: echo "value=${{ secrets.GHA_SECRETS_TEST }}" >> $GITHUB_OUTPUT
       - name: Gen new random secret
         id: new
-        run: echo "::set-output name=value::$(tr -dc 'a-zA-Z0-9' < /dev/random | head -c10)"
+        run: echo "value=$(tr -dc 'a-zA-Z0-9' < /dev/random | head -c10)" >> $GITHUB_OUTPUT
       - uses: ./.
         with:
           token: ${{ secrets.TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: |
           npm install
           npm run build

--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ inputs:
     description: 'The repository to add the secret to. Defaults to the repository running this action'
     default: '${{ github.repository }}'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
# UPDATES

- update Github Actions actions/checkout@v2 to v4
- substitute `set-output` for `>> $GITHUB_OUTPUT`
    - reference https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- upgrade NodeJS 16 to 20